### PR TITLE
refactor: Remove MediatR and rename DTOs to Response models

### DIFF
--- a/src/Jobs.Worker.Api/Jobs.Worker.Api.csproj
+++ b/src/Jobs.Worker.Api/Jobs.Worker.Api.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="MediatR" Version="12.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jobs.Worker.Application/Commands/CreateJobCommand.cs
+++ b/src/Jobs.Worker.Application/Commands/CreateJobCommand.cs
@@ -1,9 +1,8 @@
 using Jobs.Worker.Domain.Enums;
-using MediatR;
 
 namespace Jobs.Worker.Application.Commands;
 
-public record CreateJobCommand : IRequest<Guid>
+public record CreateJobCommand
 {
     public string Name { get; init; } = string.Empty;
     public string Description { get; init; } = string.Empty;

--- a/src/Jobs.Worker.Application/Commands/CreateScheduleCommand.cs
+++ b/src/Jobs.Worker.Application/Commands/CreateScheduleCommand.cs
@@ -1,9 +1,8 @@
 using Jobs.Worker.Domain.Enums;
-using MediatR;
 
 namespace Jobs.Worker.Application.Commands;
 
-public record CreateScheduleCommand : IRequest<Guid>
+public record CreateScheduleCommand
 {
     public Guid JobDefinitionId { get; init; }
     public ScheduleType ScheduleType { get; init; }

--- a/src/Jobs.Worker.Application/Commands/TriggerJobCommand.cs
+++ b/src/Jobs.Worker.Application/Commands/TriggerJobCommand.cs
@@ -1,8 +1,6 @@
-using MediatR;
-
 namespace Jobs.Worker.Application.Commands;
 
-public record TriggerJobCommand : IRequest<Guid>
+public record TriggerJobCommand
 {
     public Guid JobDefinitionId { get; init; }
     public string? InputPayload { get; init; }

--- a/src/Jobs.Worker.Application/Commands/UpdateJobStatusCommand.cs
+++ b/src/Jobs.Worker.Application/Commands/UpdateJobStatusCommand.cs
@@ -1,9 +1,8 @@
 using Jobs.Worker.Domain.Enums;
-using MediatR;
 
 namespace Jobs.Worker.Application.Commands;
 
-public record UpdateJobStatusCommand : IRequest<Unit>
+public record UpdateJobStatusCommand
 {
     public Guid JobDefinitionId { get; init; }
     public JobStatus NewStatus { get; init; }

--- a/src/Jobs.Worker.Application/Handlers/CreateJobCommandHandler.cs
+++ b/src/Jobs.Worker.Application/Handlers/CreateJobCommandHandler.cs
@@ -3,11 +3,10 @@ using Jobs.Worker.Application.Interfaces;
 using Jobs.Worker.Domain.Entities;
 using Jobs.Worker.Domain.Enums;
 using Jobs.Worker.Domain.ValueObjects;
-using MediatR;
 
 namespace Jobs.Worker.Application.Handlers;
 
-public class CreateJobCommandHandler : IRequestHandler<CreateJobCommand, Guid>
+public class CreateJobCommandHandler
 {
     private readonly IJobRepository _jobRepository;
     private readonly IAuditRepository _auditRepository;
@@ -18,7 +17,7 @@ public class CreateJobCommandHandler : IRequestHandler<CreateJobCommand, Guid>
         _auditRepository = auditRepository;
     }
 
-    public async Task<Guid> Handle(CreateJobCommand request, CancellationToken cancellationToken)
+    public async Task<Guid> HandleAsync(CreateJobCommand request, CancellationToken cancellationToken = default)
     {
         var job = new JobDefinition(
             request.Name,

--- a/src/Jobs.Worker.Application/Handlers/GetDashboardStatsQueryHandler.cs
+++ b/src/Jobs.Worker.Application/Handlers/GetDashboardStatsQueryHandler.cs
@@ -1,12 +1,11 @@
-using Jobs.Worker.Application.DTOs;
 using Jobs.Worker.Application.Interfaces;
 using Jobs.Worker.Application.Queries;
+using Jobs.Worker.Application.Responses;
 using Jobs.Worker.Domain.Enums;
-using MediatR;
 
 namespace Jobs.Worker.Application.Handlers;
 
-public class GetDashboardStatsQueryHandler : IRequestHandler<GetDashboardStatsQuery, DashboardStatsDto>
+public class GetDashboardStatsQueryHandler
 {
     private readonly IJobRepository _jobRepository;
     private readonly IJobExecutionRepository _executionRepository;
@@ -19,7 +18,7 @@ public class GetDashboardStatsQueryHandler : IRequestHandler<GetDashboardStatsQu
         _executionRepository = executionRepository;
     }
 
-    public async Task<DashboardStatsDto> Handle(GetDashboardStatsQuery request, CancellationToken cancellationToken)
+    public async Task<DashboardStatsResponse> HandleAsync(GetDashboardStatsQuery request, CancellationToken cancellationToken = default)
     {
         var allJobs = await _jobRepository.GetAllAsync(cancellationToken);
         var runningExecutions = await _executionRepository.GetRunningExecutionsAsync(cancellationToken);
@@ -39,7 +38,7 @@ public class GetDashboardStatsQueryHandler : IRequestHandler<GetDashboardStatsQu
         var totalToday = succeededToday + failedToday.Count();
         var successRate = totalToday > 0 ? (double)succeededToday / totalToday * 100 : 100.0;
 
-        return new DashboardStatsDto
+        return new DashboardStatsResponse
         {
             TotalJobs = totalJobs,
             ActiveJobs = activeJobs,

--- a/src/Jobs.Worker.Application/Handlers/TriggerJobCommandHandler.cs
+++ b/src/Jobs.Worker.Application/Handlers/TriggerJobCommandHandler.cs
@@ -2,11 +2,10 @@ using Jobs.Worker.Application.Commands;
 using Jobs.Worker.Application.Interfaces;
 using Jobs.Worker.Domain.Entities;
 using Jobs.Worker.Domain.ValueObjects;
-using MediatR;
 
 namespace Jobs.Worker.Application.Handlers;
 
-public class TriggerJobCommandHandler : IRequestHandler<TriggerJobCommand, Guid>
+public class TriggerJobCommandHandler
 {
     private readonly IJobRepository _jobRepository;
     private readonly IJobExecutionRepository _executionRepository;
@@ -22,7 +21,7 @@ public class TriggerJobCommandHandler : IRequestHandler<TriggerJobCommand, Guid>
         _auditRepository = auditRepository;
     }
 
-    public async Task<Guid> Handle(TriggerJobCommand request, CancellationToken cancellationToken)
+    public async Task<Guid> HandleAsync(TriggerJobCommand request, CancellationToken cancellationToken = default)
     {
         var job = await _jobRepository.GetByIdAsync(request.JobDefinitionId, cancellationToken)
             ?? throw new InvalidOperationException($"Job {request.JobDefinitionId} not found");

--- a/src/Jobs.Worker.Application/Jobs.Worker.Application.csproj
+++ b/src/Jobs.Worker.Application/Jobs.Worker.Application.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
-    <PackageReference Include="MediatR" Version="12.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jobs.Worker.Application/Queries/GetAllJobsQuery.cs
+++ b/src/Jobs.Worker.Application/Queries/GetAllJobsQuery.cs
@@ -1,6 +1,3 @@
-using Jobs.Worker.Application.DTOs;
-using MediatR;
-
 namespace Jobs.Worker.Application.Queries;
 
-public record GetAllJobsQuery : IRequest<IEnumerable<JobDefinitionDto>>;
+public record GetAllJobsQuery;

--- a/src/Jobs.Worker.Application/Queries/GetDashboardStatsQuery.cs
+++ b/src/Jobs.Worker.Application/Queries/GetDashboardStatsQuery.cs
@@ -1,6 +1,3 @@
-using Jobs.Worker.Application.DTOs;
-using MediatR;
-
 namespace Jobs.Worker.Application.Queries;
 
-public record GetDashboardStatsQuery : IRequest<DashboardStatsDto>;
+public record GetDashboardStatsQuery;

--- a/src/Jobs.Worker.Application/Queries/GetExecutionsByJobIdQuery.cs
+++ b/src/Jobs.Worker.Application/Queries/GetExecutionsByJobIdQuery.cs
@@ -1,6 +1,3 @@
-using Jobs.Worker.Application.DTOs;
-using MediatR;
-
 namespace Jobs.Worker.Application.Queries;
 
-public record GetExecutionsByJobIdQuery(Guid JobId, int PageSize = 50) : IRequest<IEnumerable<JobExecutionDto>>;
+public record GetExecutionsByJobIdQuery(Guid JobId, int PageSize = 50);

--- a/src/Jobs.Worker.Application/Queries/GetFailedExecutionsTodayQuery.cs
+++ b/src/Jobs.Worker.Application/Queries/GetFailedExecutionsTodayQuery.cs
@@ -1,6 +1,3 @@
-using Jobs.Worker.Application.DTOs;
-using MediatR;
-
 namespace Jobs.Worker.Application.Queries;
 
-public record GetFailedExecutionsTodayQuery : IRequest<IEnumerable<JobExecutionDto>>;
+public record GetFailedExecutionsTodayQuery;

--- a/src/Jobs.Worker.Application/Queries/GetJobByIdQuery.cs
+++ b/src/Jobs.Worker.Application/Queries/GetJobByIdQuery.cs
@@ -1,6 +1,3 @@
-using Jobs.Worker.Application.DTOs;
-using MediatR;
-
 namespace Jobs.Worker.Application.Queries;
 
-public record GetJobByIdQuery(Guid JobId) : IRequest<JobDefinitionDto?>;
+public record GetJobByIdQuery(Guid JobId);

--- a/src/Jobs.Worker.Application/Queries/GetRunningExecutionsQuery.cs
+++ b/src/Jobs.Worker.Application/Queries/GetRunningExecutionsQuery.cs
@@ -1,6 +1,3 @@
-using Jobs.Worker.Application.DTOs;
-using MediatR;
-
 namespace Jobs.Worker.Application.Queries;
 
-public record GetRunningExecutionsQuery : IRequest<IEnumerable<JobExecutionDto>>;
+public record GetRunningExecutionsQuery;

--- a/src/Jobs.Worker.Application/Responses/DashboardStatsResponse.cs
+++ b/src/Jobs.Worker.Application/Responses/DashboardStatsResponse.cs
@@ -1,6 +1,6 @@
-namespace Jobs.Worker.Application.DTOs;
+namespace Jobs.Worker.Application.Responses;
 
-public record DashboardStatsDto
+public record DashboardStatsResponse
 {
     public int TotalJobs { get; init; }
     public int ActiveJobs { get; init; }

--- a/src/Jobs.Worker.Application/Responses/JobDefinitionResponse.cs
+++ b/src/Jobs.Worker.Application/Responses/JobDefinitionResponse.cs
@@ -1,8 +1,8 @@
 using Jobs.Worker.Domain.Enums;
 
-namespace Jobs.Worker.Application.DTOs;
+namespace Jobs.Worker.Application.Responses;
 
-public record JobDefinitionDto
+public record JobDefinitionResponse
 {
     public Guid Id { get; init; }
     public string Name { get; init; } = string.Empty;

--- a/src/Jobs.Worker.Application/Responses/JobExecutionResponse.cs
+++ b/src/Jobs.Worker.Application/Responses/JobExecutionResponse.cs
@@ -1,8 +1,8 @@
 using Jobs.Worker.Domain.Enums;
 
-namespace Jobs.Worker.Application.DTOs;
+namespace Jobs.Worker.Application.Responses;
 
-public record JobExecutionDto
+public record JobExecutionResponse
 {
     public Guid Id { get; init; }
     public Guid JobDefinitionId { get; init; }

--- a/src/Jobs.Worker.Application/Responses/JobScheduleResponse.cs
+++ b/src/Jobs.Worker.Application/Responses/JobScheduleResponse.cs
@@ -1,8 +1,8 @@
 using Jobs.Worker.Domain.Enums;
 
-namespace Jobs.Worker.Application.DTOs;
+namespace Jobs.Worker.Application.Responses;
 
-public record JobScheduleDto
+public record JobScheduleResponse
 {
     public Guid Id { get; init; }
     public Guid JobDefinitionId { get; init; }

--- a/src/Jobs.Worker.Worker/Jobs.Worker.Worker.csproj
+++ b/src/Jobs.Worker.Worker/Jobs.Worker.Worker.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="MediatR" Version="12.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Removed MediatR package from all projects (Application, API, Worker)
- Renamed all DTOs to use Response suffix for better clarity:
  * DashboardStatsDto → DashboardStatsResponse
  * JobDefinitionDto → JobDefinitionResponse
  * JobExecutionDto → JobExecutionResponse
  * JobScheduleDto → JobScheduleResponse
- Moved Response models from DTOs/ to Responses/ directory
- Simplified Commands and Queries - removed IRequest interfaces
- Updated Handlers to use HandleAsync() instead of Handle()
- Removed IRequestHandler interfaces from all handlers
- Updated API endpoints to inject handlers directly via DI
- Simplified DI registration - no more MediatR scan
- Architecture is now cleaner with less abstraction overhead

Benefits:
- Simpler, more straightforward architecture
- No unnecessary CQRS overhead
- Direct handler injection is faster
- Better naming conventions (Response vs Dto)
- Easier to understand for new developers